### PR TITLE
Fix bug with loss of enchantment level after item drop

### DIFF
--- a/src/game/server/mmocore/ComponentsCore/InventoryJob/ItemInventory.cpp
+++ b/src/game/server/mmocore/ComponentsCore/InventoryJob/ItemInventory.cpp
@@ -250,9 +250,9 @@ bool CInventoryItem::Drop(int Count)
 	if(length(Force) > 8.0f)
 		Force = normalize(Force) * 8.0f;
 
+	CInventoryItem DropItem = *this;
 	if(Remove(Count))
 	{
-		CInventoryItem DropItem = *this;
 		DropItem.m_Count = Count;
 		GS()->CreateDropItem(m_pCharacter->m_Core.m_Pos, -1, DropItem, Force);
 		return true;


### PR DESCRIPTION
we copy after performing Remove, and in turn it resets the data if the item was last